### PR TITLE
Add assertion to ensure non-empty array in parseCommand method

### DIFF
--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -18,7 +18,7 @@ class Parser {
      */
     static Command parseCommand(String command) throws DukeException {
         String[] parts = command.split(" ", 2);
-
+        assert parts.length > 0;
         // Ensure there's at least one part
         if (parts.length < 1) {
             throw new DukeException("Command is empty.");


### PR DESCRIPTION
This commit adds an assertion to the parseCommand method in the Parser class to ensure that the array 'parts' has at least one element before further processing. The added assertion enhances the robustness of the code by catching unexpected conditions early in development.

Changes made in this commit:
- Added assertion 'assert parts.length > 0;' to validate the length of the array 'parts'.

This assertion serves as a safeguard against potential runtime errors and improves the overall reliability of the command parsing logic.